### PR TITLE
Fix deployment rake task

### DIFF
--- a/tasks/deploy.rake
+++ b/tasks/deploy.rake
@@ -17,26 +17,25 @@ namespace :deploy do
   # Do some file system manipulation to make sure that the app exists in
   # the app path, and that puma is ready to configure and start up.
   task :setup_machine, [:env] do |_t, args|
-    run_vagrant_ssh(args[:env], "sudo mkdir -p #{AppConfig::APP_PATH}")
-    run_vagrant_ssh(args[:env], "sudo cp -R /vagrant/* #{AppConfig::APP_PATH}")
-    run_vagrant_ssh(args[:env], "sudo chown -R vagrant #{AppConfig::APP_PATH}")
-
-    run_vagrant_ssh(args[:env], "cd #{AppConfig::APP_PATH}; bundle install")
+    run_vagrant_ssh(args[:env], "sudo rm -rf #{AppConfig::APP_PATH}; "\
+                                "sudo mkdir -p #{AppConfig::APP_PATH}; "\
+                                "cd #{AppConfig::APP_PATH}; "\
+                                'sudo cp -R /vagrant/* .; '\
+                                'sudo chown -R vagrant .; '\
+                                'bundle install')
   end
 
   task :configure_puma, [:env] => :setup_machine do |_t, args|
     puma_config = File.join(AppConfig::APP_PATH, 'deployment/puma.conf')
+    env_config = File.join(AppConfig::APP_PATH, 'config/environment')
 
-    run_vagrant_ssh(args[:env], "sudo cp #{puma_config} /etc/init/")
-    run_vagrant_ssh(args[:env], "mkdir -p #{File.join(AppConfig::APP_PATH, 'run/log')}")
-    run_vagrant_ssh(args[:env], "sudo chown vagrant #{File.join(AppConfig::APP_PATH, 'config')}")
-    run_vagrant_ssh(
-      args[:env],
-      "echo '#{app_env(args[:env])}' > #{File.join(AppConfig::APP_PATH, 'config/environment')}"
-    )
+    run_vagrant_ssh(args[:env], "sudo cp #{puma_config} /etc/init/; "\
+                                "mkdir -p #{File.join(AppConfig::APP_PATH, 'run/log')}; "\
+                                "sudo chown vagrant #{File.join(AppConfig::APP_PATH, 'config')}; "\
+                                "echo '#{app_env(args[:env])}' > #{env_config}")
   end
 
   task :start_puma, [:env] => :configure_puma do |_t, args|
-    run_vagrant_ssh(args[:env], 'sudo service puma start')
+    run_vagrant_ssh(args[:env], 'sudo service puma restart')
   end
 end


### PR DESCRIPTION
- wipe out everything from `/opt/search_services` before copying code
  there, so that no vestigial code remains

- restart the service instead of starting it; when the service is
  already running, `service puma start` does nothing, preventing any new
  code from taking effect

- use fewer calls to `run_vagrant_ssh` where possible; each new SSH
  session takes time, but the operations in the rake task are so simple;
  combine them where possible for better efficiency

@Jkovarik 