### PR TITLE
Fix data access links

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -138,9 +138,11 @@ methods must return an open search response builder.
   search, enrich results
     * `Validator`
     * `SearchAdapter`
+    * `Enricher`
 * `Validator` - validate search inputs with a given search definition
 * `SearchAdapter` - executes a search by calling the execute method of a given
   search implementation with the parameters from a given parameter factory
+* `Enricher` - updates each result entry with a given set of entry enrichers
 * `App` - the main application
     * `Sinatra::Base`
     * `Controllers::DatasetOsdd`

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -1,4 +1,5 @@
 :development:
+  :enricher_thread_count: 5
   :relative_url_root: /
   :solr_url: http://localhost:8983/solr/nsidc_oai
   :solr_auto_suggest_url: http://localhost:8983/solr/auto_suggest
@@ -6,6 +7,7 @@
   :metrics_url: http://liquid.colorado.edu:12180/metrics/projects/search/services/dataset-search-services/instances/integration
 
 :common:
+  :enricher_thread_count: 5
   :relative_url_root: /api/dataset/2
   :port: '10680'
   :num_workers: 5

--- a/lib/nsidc_open_search/controllers/dataset_search.rb
+++ b/lib/nsidc_open_search/controllers/dataset_search.rb
@@ -9,6 +9,8 @@ module NsidcOpenSearch
         app.get Routes.named(:dataset_search), provides: [:atom, :xml] do
           NsidcOpenSearch::DatasetSearch.new(
             settings.solr_url,
+            settings.dataset_catalog_services_url,
+            settings.enricher_thread_count,
             settings.query_config
           ).exec(params).to_atom(request.url, base_url)
         end

--- a/lib/nsidc_open_search/dataset_search.rb
+++ b/lib/nsidc_open_search/dataset_search.rb
@@ -5,6 +5,7 @@ require_relative 'dataset/search/solr_search_dataset'
 require_relative 'dataset/search/factories/parameter_results_factory'
 require_relative 'dataset/search/parsers/solr_results_parser'
 require_relative 'dataset/model/search/open_search_response_builder'
+require_relative 'entry_enrichers/iso'
 
 module NsidcOpenSearch
   class DatasetSearch
@@ -13,7 +14,7 @@ module NsidcOpenSearch
     search_definition NsidcOpenSearch::Dataset::Search::Definition
     param_factory NsidcOpenSearch::Dataset::Search::ResultsParameterFactory
 
-    def initialize(url, query_config)
+    def initialize(url, iso_service_url, enricher_thread_count, query_config)
       self.class.send(
         :search,
         NsidcOpenSearch::Dataset::Search::SolrSearchDataset.new(
@@ -24,6 +25,8 @@ module NsidcOpenSearch
           RSolr::Ext
         )
       )
+      self.class.send(:entry_enrichers, [NsidcOpenSearch::EntryEnrichers::Iso.new(iso_service_url)])
+      self.class.send(:enricher_thread_count, enricher_thread_count)
     end
   end
 end

--- a/lib/nsidc_open_search/enricher.rb
+++ b/lib/nsidc_open_search/enricher.rb
@@ -1,0 +1,39 @@
+require 'peach'
+require_relative '../utils/class_module'
+
+module NsidcOpenSearch
+  module Enricher
+    extend ClassModule
+
+    DEFAULT_THREAD_COUNT = 5
+
+    module ClassMethods
+      def entry_enrichers(enrichers)
+        send :define_method, :enrichers do
+          enrichers
+        end
+      end
+
+      def enricher_thread_count(thread_count)
+        return unless thread_count.is_a? Numeric
+
+        send :define_method, :thread_count do
+          thread_count
+        end
+      end
+    end
+
+    module InstanceMethods
+      def enrich_result(result)
+        return unless defined?(enrichers)
+
+        threads = defined?(thread_count) ? thread_count : DEFAULT_THREAD_COUNT
+        result.entries.peach(threads) do |entry|
+          enrichers.each do |enricher|
+            enricher.enrich_entry entry
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/nsidc_open_search/entry_enrichers/iso.rb
+++ b/lib/nsidc_open_search/entry_enrichers/iso.rb
@@ -1,0 +1,58 @@
+require 'date'
+require 'nokogiri'
+require 'rest_client'
+require_relative '../dataset/model/search/data_access'
+require_relative '../../utils/nokogiri_xml_node_iso'
+
+module NsidcOpenSearch
+  module EntryEnrichers
+    class Iso
+      def initialize(iso_url)
+        @iso_url = iso_url
+      end
+
+      def enrich_entry(entry)
+        begin
+          iso_document = RestClient.get("#{@iso_url}/#{entry.id}")
+        rescue
+          # log.info('Result entry cannot be enriched without an iso document')
+          return
+        end
+
+        doc = Nokogiri::XML iso_document.sub(
+          /<gmi:MI_Metadata version="1.0">/,
+          '<gmi:MI_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" '\
+          'xmlns:gmd="http://www.isotc211.org/2005/gmd" '\
+          'xmlns:gml="http://www.opengis.net/gml/3.2" '\
+          'xmlns:gts="http://www.isotc211.org/2005/gts" '\
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '\
+          'xmlns:gmi="http://www.isotc211.org/2005/gmi" version="1.0">')
+
+        entry.data_access = data_access doc
+        entry.supporting_programs = supporting_programs doc
+      end
+
+      private
+
+      def data_access(doc)
+        doc.xpath('//gmd:MD_DigitalTransferOptions/gmd:onLine').map do |e|
+          NsidcOpenSearch::Dataset::Model::Search::DataAccess.new(
+            url: e.at_xpath('.//gmd:URL').text.strip,
+            name: e.at_xpath('.//gmd:name').iso_character_string,
+            description: e.at_xpath('.//gmd:description').iso_character_string,
+            type: e.at_xpath('.//gmd:CI_OnlineResource//gmd:CI_OnLineFunctionCode').text.strip
+          )
+        end
+      end
+
+      def supporting_programs(doc)
+        path = '//gmd:MD_DataIdentification/'\
+               'gmd:pointOfContact/'\
+               'gmd:CI_ResponsibleParty[.//gmd:CI_RoleCode="custodian"]/'\
+               'gmd:organisationShortName'
+
+        doc.xpath(path).map(&:iso_character_string)
+      end
+    end
+  end
+end

--- a/lib/nsidc_open_search/search.rb
+++ b/lib/nsidc_open_search/search.rb
@@ -1,6 +1,7 @@
 require File.join(File.dirname(__FILE__), '..', 'utils', 'class_module')
 require File.join(File.dirname(__FILE__), 'validator')
 require File.join(File.dirname(__FILE__), 'search_adapter')
+require File.join(File.dirname(__FILE__), 'enricher')
 
 module NsidcOpenSearch
   module Search
@@ -8,10 +9,12 @@ module NsidcOpenSearch
 
     include Validator::InstanceMethods
     include SearchAdapter::InstanceMethods
+    include Enricher::InstanceMethods
 
     module ClassMethods
       include Validator::ClassMethods
       include SearchAdapter::ClassMethods
+      include Enricher::ClassMethods
     end
 
     def exec(parameters)
@@ -22,7 +25,10 @@ module NsidcOpenSearch
                             'in the OpenSearch description document.'
       end
 
-      execute_search(parameters, valid_terms)
+      result = execute_search parameters, valid_terms
+      enrich_result result
+
+      result
     end
 
     def exec_rest(parameters)

--- a/lib/nsidc_open_search/search.rb
+++ b/lib/nsidc_open_search/search.rb
@@ -1,7 +1,7 @@
-require File.join(File.dirname(__FILE__), '..', 'utils', 'class_module')
-require File.join(File.dirname(__FILE__), 'validator')
-require File.join(File.dirname(__FILE__), 'search_adapter')
-require File.join(File.dirname(__FILE__), 'enricher')
+require_relative '../utils/class_module'
+require_relative 'enricher'
+require_relative 'search_adapter'
+require_relative 'validator'
 
 module NsidcOpenSearch
   module Search
@@ -18,22 +18,22 @@ module NsidcOpenSearch
     end
 
     def exec(parameters)
-      validate! parameters
+      validate!(parameters)
 
       unless valid?
         fail ArgumentError, 'Invalid search query. The query must contain all parameters specified'\
-                            'in the OpenSearch description document.'
+                            ' in the OpenSearch description document.'
       end
 
-      result = execute_search parameters, valid_terms
-      enrich_result result
+      result = exec_rest(parameters)
+
+      enrich_result(result) unless parameters['source'] == 'ADE'
 
       result
     end
 
     def exec_rest(parameters)
-      result = execute_search parameters, valid_terms
-      result
+      execute_search(parameters, valid_terms)
     end
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -56,7 +56,8 @@ describe 'Nsidc OpenSearch App' do
         'docs' => [
           {
             'authoritative_id' => '12345',
-            'title' => 'test'
+            'title' => 'test',
+            'iso' => iso_document_fixture
           }
         ]
       }
@@ -64,6 +65,7 @@ describe 'Nsidc OpenSearch App' do
 
     rsolr = double('rsolr', find: solr_response)
     allow(RSolr::Ext).to receive(:connect).and_return(rsolr)
+    allow(RestClient).to receive(:get).and_return(iso_document_fixture)
 
     get('/OpenSearch', default_os_query_params,
         'HTTP_ACCEPT' => 'application/atom+xml',

--- a/spec/enricher_spec.rb
+++ b/spec/enricher_spec.rb
@@ -1,0 +1,28 @@
+require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.join(File.dirname(__FILE__), '..', 'lib', 'nsidc_open_search', 'enricher')
+
+describe 'enricher' do
+  describe 'enrich result' do
+    before :each do
+      @result = double('result', entries: [{}])
+
+      @obj = Object.new
+      @obj.class.send :include, NsidcOpenSearch::Enricher
+    end
+
+    it 'should call enrich entry for each entry' do
+      entry_enricher = double('entry enricher', enrich_entry: nil)
+      @obj.class.send :entry_enrichers, [entry_enricher]
+
+      @obj.enrich_result @result
+      expect(entry_enricher).to have_received(:enrich_entry).exactly(@result.entries.length).times
+
+      @obj.class.send :remove_method, :enrichers
+    end
+
+    it 'should handle empty entry enrichers list' do
+      @obj.enrich_result @result
+      expect(@result.entries).to eql [{}]
+    end
+  end
+end

--- a/spec/fixtures/iso_document.xml
+++ b/spec/fixtures/iso_document.xml
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gmi:MI_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gmi="http://www.isotc211.org/2005/gmi" version="1.0">
+    <gmd:dateStamp>
+        <gco:Date>20130528</gco:Date>
+    </gmd:dateStamp>
+    <gmd:dataSetURI>
+        <gco:CharacterString>http://nsidc.org/data/test</gco:CharacterString>
+    </gmd:dataSetURI>
+    <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+            <gmd:citation>
+                <gmd:CI_Citation>
+                    <gmd:citedResponsibleParty>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:individualName>
+                                <gco:CharacterString>Jane Doe</gco:CharacterString>
+                            </gmd:individualName>
+                            <gmd:organisationName>
+                                <gco:CharacterString>National Snow and Ice Data Center</gco:CharacterString>
+                            </gmd:organisationName>
+                            <gmd:positionName>
+                                <gco:CharacterString>none</gco:CharacterString>
+                            </gmd:positionName>
+                            <gmd:contactInfo>
+                                <gmd:CI_Contact>
+                                    <gmd:phone>
+                                        <gmd:CI_Telephone>
+                                            <gmd:voice>
+                                                <gco:CharacterString>1 303 492-6199</gco:CharacterString>
+                                            </gmd:voice>
+                                        </gmd:CI_Telephone>
+                                    </gmd:phone>
+                                    <gmd:address>
+                                        <gmd:CI_Address>
+                                            <gmd:deliveryPoint>
+                                                <gco:CharacterString>National Snow and Ice Data Center</gco:CharacterString>
+                                            </gmd:deliveryPoint>
+                                            <gmd:city>
+                                                <gco:CharacterString>Boulder</gco:CharacterString>
+                                            </gmd:city>
+                                            <gmd:administrativeArea>
+                                                <gco:CharacterString>CO</gco:CharacterString>
+                                            </gmd:administrativeArea>
+                                            <gmd:postalCode>
+                                                <gco:CharacterString>80309-0449</gco:CharacterString>
+                                            </gmd:postalCode>
+                                            <gmd:country>
+                                                <gco:CharacterString>USA</gco:CharacterString>
+                                            </gmd:country>
+                                            <gmd:electronicMailAddress>
+                                                <gco:CharacterString>nsidc@nsidc.org</gco:CharacterString>
+                                            </gmd:electronicMailAddress>
+                                        </gmd:CI_Address>
+                                    </gmd:address>
+                                    <gmd:onlineResource>
+                                        <gmd:CI_OnlineResource>
+                                            <gmd:linkage>
+                                                <gmd:URL>http://nsidc.org</gmd:URL>
+                                            </gmd:linkage>
+                                        </gmd:CI_OnlineResource>
+                                    </gmd:onlineResource>
+                                </gmd:CI_Contact>
+                            </gmd:contactInfo>
+                            <gmd:role>
+                                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="principalInvestigator">principalInvestigator</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:citedResponsibleParty>
+                    <gmd:citedResponsibleParty>
+                        <gmd:CI_ResponsibleParty>
+                            <gmd:individualName>
+                                <gco:CharacterString>John Doe</gco:CharacterString>
+                            </gmd:individualName>
+                            <gmd:organisationName>
+                                <gco:CharacterString>
+                                    Making Earth System Data Records for Use in Research Environments
+                                </gco:CharacterString>
+                            </gmd:organisationName>
+                            <gmd:positionName>
+                                <gco:CharacterString>none</gco:CharacterString>
+                            </gmd:positionName>
+                            <gmd:contactInfo>
+                                <gmd:CI_Contact>
+                                    <gmd:address>
+                                        <gmd:CI_Address>
+                                            <gmd:electronicMailAddress>
+                                                <gco:CharacterString>nsidc@nsidc.org</gco:CharacterString>
+                                            </gmd:electronicMailAddress>
+                                        </gmd:CI_Address>
+                                    </gmd:address>
+                                    <gmd:onlineResource>
+                                        <gmd:CI_OnlineResource>
+                                            <gmd:linkage>
+                                                <gmd:URL>Unknown</gmd:URL>
+                                            </gmd:linkage>
+                                        </gmd:CI_OnlineResource>
+                                    </gmd:onlineResource>
+                                </gmd:CI_Contact>
+                            </gmd:contactInfo>
+                            <gmd:role>
+                                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="principalInvestigator">principalInvestigator</gmd:CI_RoleCode>
+                            </gmd:role>
+                        </gmd:CI_ResponsibleParty>
+                    </gmd:citedResponsibleParty>
+                </gmd:CI_Citation>
+            </gmd:citation>
+            <gmd:abstract>
+                <gco:CharacterString>
+                    Test Abstract
+                </gco:CharacterString>
+            </gmd:abstract>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:individualName>
+                        <gco:CharacterString>NSIDC MEaSUREs User Services</gco:CharacterString>
+                    </gmd:individualName>
+                    <gmd:organisationName>
+                        <gco:CharacterString>
+                            Making Earth System Data Records for Use in Research Environments
+                        </gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:organisationShortName>
+                      <gco:CharacterString>
+                        NSIDC_MEASURES
+                      </gco:CharacterString>
+                    </gmd:organisationShortName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:onlineResource>
+                                <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                        <gmd:URL>http://nsidc.org</gmd:URL>
+                                    </gmd:linkage>
+                                    <gmd:name gco:nilReason="missing"/>
+                                    <gmd:description gco:nilReason="missing"/>
+                                </gmd:CI_OnlineResource>
+                            </gmd:onlineResource>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:pointOfContact>
+                <gmd:CI_ResponsibleParty>
+                    <gmd:individualName>
+                        <gco:CharacterString>NSIDC User Services</gco:CharacterString>
+                    </gmd:individualName>
+                    <gmd:organisationName>
+                        <gco:CharacterString>NASA DAAC at the National Snow and Ice Data Center</gco:CharacterString>
+                    </gmd:organisationName>
+                    <gmd:organisationShortName>
+                      <gco:CharacterString>
+                        NSIDC_DAAC
+                      </gco:CharacterString>
+                    </gmd:organisationShortName>
+                    <gmd:contactInfo>
+                        <gmd:CI_Contact>
+                            <gmd:phone>
+                                <gmd:CI_Telephone>
+                                    <gmd:voice>
+                                        <gco:CharacterString>1 303 492 6199 x</gco:CharacterString>
+                                    </gmd:voice>
+                                    <gmd:facsimile>
+                                        <gco:CharacterString>1 303 492 2468 x</gco:CharacterString>
+                                    </gmd:facsimile>
+                                </gmd:CI_Telephone>
+                            </gmd:phone>
+                            <gmd:address>
+                                <gmd:CI_Address>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>National Snow and Ice Data Center</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>CIRES, 449 UCB</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:deliveryPoint>
+                                        <gco:CharacterString>University of Colorado</gco:CharacterString>
+                                    </gmd:deliveryPoint>
+                                    <gmd:city>
+                                        <gco:CharacterString>Boulder</gco:CharacterString>
+                                    </gmd:city>
+                                    <gmd:administrativeArea>
+                                        <gco:CharacterString>CO</gco:CharacterString>
+                                    </gmd:administrativeArea>
+                                    <gmd:postalCode>
+                                        <gco:CharacterString>80309-0449</gco:CharacterString>
+                                    </gmd:postalCode>
+                                    <gmd:country>
+                                        <gco:CharacterString>USA</gco:CharacterString>
+                                    </gmd:country>
+                                    <gmd:electronicMailAddress>
+                                        <gco:CharacterString>nsidc@nsidc.org</gco:CharacterString>
+                                    </gmd:electronicMailAddress>
+                                </gmd:CI_Address>
+                            </gmd:address>
+                            <gmd:onlineResource>
+                                <gmd:CI_OnlineResource>
+                                    <gmd:linkage>
+                                        <gmd:URL>http://nsidc.org</gmd:URL>
+                                    </gmd:linkage>
+                                    <gmd:name gco:nilReason="missing"/>
+                                    <gmd:description gco:nilReason="missing"/>
+                                </gmd:CI_OnlineResource>
+                            </gmd:onlineResource>
+                        </gmd:CI_Contact>
+                    </gmd:contactInfo>
+                    <gmd:role>
+                        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+                    </gmd:role>
+                </gmd:CI_ResponsibleParty>
+            </gmd:pointOfContact>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>
+                            Place
+                        </gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="place">place</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>
+                            Discipline
+                        </gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="discipline">discipline</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                    <gmd:keyword>
+                        <gco:CharacterString>
+                            Theme
+                        </gco:CharacterString>
+                    </gmd:keyword>
+                    <gmd:type>
+                        <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+                    </gmd:type>
+                </gmd:MD_Keywords>
+            </gmd:descriptiveKeywords>
+            <gmd:extent>
+                <gmd:EX_Extent id="boundingExtent">
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicBoundingBox id="boundingGeographicBoundingBox">
+                            <gmd:westBoundingLongitude>
+                                <gco:Decimal>-180</gco:Decimal>
+                            </gmd:westBoundingLongitude>
+                            <gmd:eastBoundingLongitude>
+                                <gco:Decimal>180</gco:Decimal>
+                            </gmd:eastBoundingLongitude>
+                            <gmd:southBoundingLatitude>
+                                <gco:Decimal>30.98</gco:Decimal>
+                            </gmd:southBoundingLatitude>
+                            <gmd:northBoundLatitude>
+                                <gco:Decimal>90</gco:Decimal>
+                            </gmd:northBoundLatitude>
+                        </gmd:EX_GeographicBoundingBox>
+                    </gmd:geographicElement>
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicBoundingBox id="boundingGeographicBoundingBox">
+                            <gmd:westBoundingLongitude>
+                                <gco:Decimal>-180</gco:Decimal>
+                            </gmd:westBoundingLongitude>
+                            <gmd:eastBoundingLongitude>
+                                <gco:Decimal>180</gco:Decimal>
+                            </gmd:eastBoundingLongitude>
+                            <gmd:southBoundingLatitude>
+                                <gco:Decimal>-90</gco:Decimal>
+                            </gmd:southBoundingLatitude>
+                            <gmd:northBoundLatitude>
+                                <gco:Decimal>-39.23</gco:Decimal>
+                            </gmd:northBoundLatitude>
+                        </gmd:EX_GeographicBoundingBox>
+                    </gmd:geographicElement>
+                    <gmd:temporalElement>
+                        <gmd:EX_TemporalExtent id="boundingTemporalExtent">
+                            <gmd:extent>
+                                <gml:TimePeriod>
+                                    <gml:beginPosition>19781001</gml:beginPosition>
+                                    <gml:endPosition>20111231</gml:endPosition>
+                                </gml:TimePeriod>
+                            </gmd:extent>
+                        </gmd:EX_TemporalExtent>
+                    </gmd:temporalElement>
+                </gmd:EX_Extent>
+            </gmd:extent>
+        </gmd:MD_DataIdentification>
+    </gmd:identificationInfo>
+    <gmd:distributionInfo>
+        <gmd:MD_Distribution>
+            <gmd:MD_DigitalTransferOptions>
+                <gmd:onLine>
+                    <gmd:CI_OnlineResource>
+                        <gmd:linkage>
+                            <gmd:URL>
+                                ftp://sidads.colorado.edu/pub/DATASETS/fgdc/ggd221_soiltemp_antarctica/
+                            </gmd:URL>
+                        </gmd:linkage>
+                        <gmd:name>
+                          <gco:CharacterString>Get Data</gco:CharacterString>
+                        </gmd:name>
+                        <gmd:description>
+                            <gco:CharacterString>Data Access URL</gco:CharacterString>
+                        </gmd:description>
+                        <gmd:function>
+                          <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="function">download</gmd:CI_OnLineFunctionCode>
+                        </gmd:function>
+                    </gmd:CI_OnlineResource>
+                </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+            <gmd:distributionFormat>
+                <gmd:MD_Format>
+                    <gmd:name>
+                        <gco:CharacterString>ASCII Text</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:specification>
+                        <gco:CharacterString>FTP</gco:CharacterString>
+                    </gmd:specification>
+                </gmd:MD_Format>
+            </gmd:distributionFormat>
+        </gmd:MD_Distribution>
+    </gmd:distributionInfo>
+</gmi:MI_Metadata>

--- a/spec/iso_enricher_spec.rb
+++ b/spec/iso_enricher_spec.rb
@@ -1,0 +1,34 @@
+require_relative 'spec_helper'
+require_relative '../lib/nsidc_open_search/dataset/model/search/result_entry'
+require_relative '../lib/nsidc_open_search/entry_enrichers/iso'
+
+describe NsidcOpenSearch::EntryEnrichers::Iso do
+  before :each do
+    allow(RestClient).to receive(:get).and_return(iso_document_fixture)
+    @result_entry = NsidcOpenSearch::Dataset::Model::Search::ResultEntry.new(id: '12345')
+  end
+
+  describe '#enrich_entry' do
+    def described_method(entry)
+      described_class.new('http://testurl.org/test').enrich_entry(entry)
+    end
+
+    it 'should set a data access' do
+      described_method(@result_entry)
+      expected_url = 'ftp://sidads.colorado.edu/pub/DATASETS/fgdc/ggd221_soiltemp_antarctica/'
+
+      expect(@result_entry.data_access.length).to be 1
+      expect(@result_entry.data_access[0].url).to eql expected_url
+      expect(@result_entry.data_access[0].name).to eql 'Get Data'
+      expect(@result_entry.data_access[0].description).to eql 'Data Access URL'
+      expect(@result_entry.data_access[0].type).to eql 'download'
+    end
+
+    it 'should set supporting programs' do
+      described_method(@result_entry)
+      expect(@result_entry.supporting_programs.length).to be 2
+      expect(@result_entry.supporting_programs[0]).to eql 'NSIDC_MEASURES'
+      expect(@result_entry.supporting_programs[1]).to eql 'NSIDC_DAAC'
+    end
+  end
+end

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -9,6 +9,7 @@ describe NsidcOpenSearch::Search do
   let(:search) { double('search impl') }
   let(:param_factory) { double('param factory impl') }
   let(:definition)  { double('search definition') }
+  let(:entry_enricher) { double('entry enricher', enrich_entry: nil) }
   let(:results) { double('results', total_results: 2, entries: [{}, {}]) }
   let(:obj) { Object.new }
 
@@ -21,15 +22,18 @@ describe NsidcOpenSearch::Search do
     obj.class.send :search_definition, definition
     obj.class.send :search, search
     obj.class.send :param_factory, param_factory
+    obj.class.send :entry_enrichers, [entry_enricher]
 
     allow(obj).to receive(:validate!).and_call_original
     allow(obj).to receive(:execute_search).and_call_original
+    allow(obj).to receive(:enrich_result).and_call_original
   end
 
-  it 'should validate input and search' do
+  it 'should validate input, search, and enrich results with valid data' do
     obj.exec params
     expect(obj).to have_received(:validate!).with(params)
     expect(obj).to have_received(:execute_search).with(params, valid_terms)
+    expect(obj).to have_received(:enrich_result).with(results)
   end
 
   it 'should return search results' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,16 @@ Bundler.require(:default, :test)
 # Require all support files
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
+def iso_document_fixture
+  File.open(File.expand_path('../fixtures/iso_document.xml', __FILE__), 'rb')  do |iso_doc_file|
+    begin
+      iso_doc_file.read
+    ensure
+      iso_doc_file.close
+    end
+  end
+end
+
 RSpec.configure do |c|
   c.filter_run_excluding disabled: true
 end


### PR DESCRIPTION
The premise of #1 was incorrect; the code that was being accessed is needed to add data access links and supporting programs for NSIDC Search; revert that change and modify the enricher code to skip enrichment when the source is ADE.