### PR TITLE
Remove 'measurements' search term from AT.

### DIFF
--- a/spec/acceptance/steps/open_search_steps.rb
+++ b/spec/acceptance/steps/open_search_steps.rb
@@ -29,8 +29,7 @@ module OpenSearchSteps
 
   step 'I make a request with a date time line crossing bounding box' do
     parameters['geo:box'] = '160.0,55.0,-160.0,80.0'
-    parameters['searchTerms'] = 'measurements'
-    parameters['count'] = '200'
+    parameters['count'] = '500'
   end
 
   step 'I make a request with date range :start_date to :end_date' do |start_date, end_date|


### PR DESCRIPTION
This change is in response to a change in the dataset summary for AE_L2A, causing it to not show up as expected.